### PR TITLE
Make any release failure turn the run red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,15 @@ jobs:
       - name: Make node dependency guard intact
         run: node scripts/verify-node-deps-guard.mjs
 
+      # The release pipeline runs only on a tag, so nothing on a PR exercises
+      # it. Every way it had of publishing nothing and reporting success was
+      # therefore invisible until a release went out. This asserts those ways
+      # stay closed, on the PR that would reopen one.
+      - name: Release failure gates intact
+        run: |
+          node scripts/verify-release-gates.mjs
+          python3 scripts/test-release-gate.py
+
       - name: Format check
         run: cargo fmt --all --check
 
@@ -273,7 +282,10 @@ jobs:
         run: make _runtime_wasm
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked || true
+        # `|| true` here hid a failed install behind a confusing `make
+        # _test_rust` error several steps later. `cargo install` is already a
+        # no-op when the binary is present, so it needs no help succeeding.
+        run: cargo install cargo-llvm-cov --locked
 
       - name: Tests with coverage
         run: make _test_rust
@@ -653,8 +665,10 @@ jobs:
         run: |
           set -euo pipefail
           sdk_root=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}
-          sdkmanager=$(ls -d "$sdk_root"/cmdline-tools/*/bin/sdkmanager 2>/dev/null | sort -V | tail -1 || true)
-          [ -x "$sdkmanager" ] || { echo "no sdkmanager under $sdk_root/cmdline-tools"; exit 1; }
+          sdk_tools="$sdk_root/cmdline-tools"
+          [ -d "$sdk_tools" ] || { echo "::error::no cmdline-tools directory under $sdk_root"; exit 1; }
+          sdkmanager=$(find "$sdk_tools" -maxdepth 3 -path '*/bin/sdkmanager' -type f | sort -V | tail -1)
+          [ -x "$sdkmanager" ] || { echo "::error::no sdkmanager under $sdk_tools"; exit 1; }
           "$sdkmanager" "ndk;28.2.13676358" "platforms;android-34" "build-tools;34.0.0"
           echo "ANDROID_HOME=$sdk_root" >> "$GITHUB_ENV"
           echo "ANDROID_NDK_HOME=$sdk_root/ndk/28.2.13676358" >> "$GITHUB_ENV"

--- a/.github/workflows/deploy-webcompiler.yml
+++ b/.github/workflows/deploy-webcompiler.yml
@@ -21,11 +21,11 @@ jobs:
 
       - name: Deploy to Fly.io
         id: deploy
-        # Optional add-on: a Fly outage or an invalid/banned FLY_API_TOKEN must
-        # not fail a release. The browser compiler is not a release artifact.
-        # But the failure must NOT be silent (that froze the live playground on a
-        # stale build for weeks) — the next step surfaces it loudly.
-        continue-on-error: true
+        # This was `continue-on-error: true` plus a warning, on the reasoning
+        # that the browser compiler is an add-on rather than a release artifact.
+        # A warning inside a green run is read by nobody, and the live playground
+        # duly served a stale build for weeks. A deploy we chose to run and that
+        # did not happen is a failure, whoever triggered it.
         run: |
           if [ -z "${FLY_API_TOKEN}" ]; then
             echo "::error title=Missing FLY_API_TOKEN::The FLY_API_TOKEN secret is empty. Mint one with 'fly tokens create deploy -a osprey' and set it via 'gh secret set FLY_API_TOKEN'."
@@ -35,13 +35,9 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Surface deploy failure
-        if: steps.deploy.outcome == 'failure'
+      # The deploy step above now fails the job by itself. This runs only on
+      # that path, to say what broke and how to fix it before the job ends.
+      - name: Explain the deploy failure
+        if: failure() && steps.deploy.outcome == 'failure'
         run: |
-          echo "::warning title=Web compiler deploy FAILED::flyctl deploy did not succeed (banned/expired token or Fly outage). The live playground backend at https://osprey.fly.dev is now STALE. Fix: 'fly tokens create deploy -a osprey' then 'gh secret set FLY_API_TOKEN'."
-          # A manual redeploy that fails should fail the run so the operator
-          # notices immediately; a release-triggered deploy stays non-fatal.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manual deploy failed — failing the job so it is not missed."
-            exit 1
-          fi
+          echo "::error title=Web compiler deploy FAILED::flyctl deploy did not succeed (banned/expired token or Fly outage). The live playground backend at https://osprey.fly.dev is STALE. Fix: 'fly tokens create deploy -a osprey' then 'gh secret set FLY_API_TOKEN'."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,12 @@ jobs:
     # binary at the new tag version). A website-only tag skips it.
     if: ${{ needs.scope.outputs.build_matrix == 'true' }}
     runs-on: ${{ matrix.os }}
-    # Windows is the newest, least-proven target — keep a win32 hiccup from
-    # blocking the mac/linux binaries + VSIX publish. A win32 failure shows as a
-    # failed leg (warning) but doesn't fail the build job.
-    continue-on-error: ${{ matrix.platform == 'win32-x64' }}
+    # Every platform is blocking. win32 was `continue-on-error`, so a Windows
+    # hiccup could not hold up the mac/linux publish — which meant a release
+    # whose Windows binary never built still reported green, and the operator
+    # heard about it from Scoop users. `fail-fast: false` stays: a failing leg
+    # must not cancel its siblings, because the point is to see every platform's
+    # result in one run. It just has to end red.
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +164,25 @@ jobs:
           staging="osprey-$v-$plat"
           mkdir -p "dist/$staging"
           cp "target/release/osprey${exe}" "dist/$staging/"
-          cp compiler/lib/lib*.a "dist/$staging/" 2>/dev/null || cp compiler/bin/lib*.a "dist/$staging/" 2>/dev/null || true
+          # The runtime archives used to be copied with `|| true`, so a build
+          # that produced none still packaged, published and reached Homebrew —
+          # a compiler that can link nothing, shipped green. Find the directory
+          # that has them and fail when neither does.
+          libdir=""
+          for candidate in compiler/lib compiler/bin; do
+            if ls "$candidate"/lib*.a >/dev/null 2>&1; then libdir="$candidate"; break; fi
+          done
+          [ -n "$libdir" ] || { echo "::error::no runtime archives in compiler/lib or compiler/bin"; exit 1; }
+          cp "$libdir"/lib*.a "dist/$staging/"
+          # Every memory backend must be in the tarball. A missing one is
+          # otherwise found by the user whose --memory=gc build fails to link.
+          for archive in fiber_runtime fiber_runtime_arc fiber_runtime_gc \
+                         http_runtime http_runtime_arc http_runtime_gc; do
+            [ -f "dist/$staging/lib${archive}.a" ] || {
+              echo "::error::lib${archive}.a missing from $staging (staged from $libdir: $(echo "$libdir"/lib*.a))"
+              exit 1
+            }
+          done
           tar -czf "dist/$staging.tar.gz" -C dist "$staging"
           # macOS ships shasum (Perl) but not sha256sum; Windows Git Bash ships
           # sha256sum but not shasum; Linux has both. Identical output format
@@ -196,28 +216,35 @@ jobs:
           fail_on_unmatched_files: true
 
   # --------------------------------------------------------------------------
-  # Token preflight — brew/scoop (BREW_SCOOP_PAT) and Open VSX (OPEN_VSX_PAT) use
-  # standing tokens that can't be minted from OIDC. Probe them once so those jobs
-  # SKIP cleanly when the token isn't configured (the Marketplace OIDC publish +
-  # binaries + GitHub Release + site still ship). Secrets aren't readable in a
-  # job-level `if:`, so we surface their presence as booleans here. Add the
-  # secrets later and re-run the skipped jobs — no re-tag needed.
+  # Credential preflight — brew/scoop (BREW_SCOOP_PAT) and Open VSX
+  # (OPEN_VSX_PAT) use standing tokens that cannot be minted from OIDC. This
+  # used to emit a *warning* and let those jobs skip, so a release that reached
+  # neither Homebrew, Scoop nor Open VSX still reported success while `brew
+  # install` kept serving the previous version. A channel we mean to publish to
+  # and cannot is a broken release, so a missing credential now fails here —
+  # before anything is built, and with the command that fixes it.
   preflight:
-    name: Probe optional publish tokens
+    name: Verify publish credentials
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    outputs:
-      has_brew: ${{ steps.probe.outputs.has_brew }}
-      has_ovsx: ${{ steps.probe.outputs.has_ovsx }}
     steps:
-      - id: probe
+      - name: Require every publish credential
         env:
           BREW_SCOOP_PAT: ${{ secrets.BREW_SCOOP_PAT }}
           OPEN_VSX_PAT: ${{ secrets.OPEN_VSX_PAT }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         run: |
           set -euo pipefail
-          if [ -n "${BREW_SCOOP_PAT:-}" ]; then echo "has_brew=true" >> "$GITHUB_OUTPUT"; else echo "has_brew=false" >> "$GITHUB_OUTPUT"; echo "::warning::BREW_SCOOP_PAT not set — Homebrew + Scoop publish will be skipped"; fi
-          if [ -n "${OPEN_VSX_PAT:-}" ];   then echo "has_ovsx=true" >> "$GITHUB_OUTPUT"; else echo "has_ovsx=false" >> "$GITHUB_OUTPUT"; echo "::warning::OPEN_VSX_PAT not set — Open VSX publish will be skipped"; fi
+          missing=""
+          for name in BREW_SCOOP_PAT OPEN_VSX_PAT AZURE_CLIENT_ID AZURE_TENANT_ID; do
+            [ -n "${!name:-}" ] || missing="$missing $name"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error title=Missing publish credentials::Not set:${missing}. Set each with 'gh secret set <NAME>'. Every release channel is required; none of them is optional."
+            exit 1
+          fi
+          echo "All publish credentials present."
 
   # --------------------------------------------------------------------------
   # Homebrew tap — shape from templates/gh-actions/publish-brew-tap.yml, adapted
@@ -225,7 +252,6 @@ jobs:
   brew:
     name: Publish Homebrew formula
     needs: [version, github-release, preflight]
-    if: ${{ needs.preflight.outputs.has_brew == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -283,7 +309,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/osprey.rb
-          git commit -m "osprey ${{ needs.version.outputs.version }}" || exit 0
+          # `git commit || exit 0` swallowed real failures along with the
+          # nothing-to-commit case, and skipped the push with them. Ask
+          # directly whether anything is staged.
+          if git diff --cached --quiet; then
+            echo "formula already at ${{ needs.version.outputs.version }} — nothing to commit"
+            exit 0
+          fi
+          git commit -m "osprey ${{ needs.version.outputs.version }}"
           git push
 
   # --------------------------------------------------------------------------
@@ -293,7 +326,6 @@ jobs:
   scoop:
     name: Publish Scoop manifest
     needs: [version, github-release, preflight]
-    if: ${{ needs.preflight.outputs.has_brew == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -344,7 +376,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add bucket/osprey.json
-          git commit -m "osprey ${{ needs.version.outputs.version }}" || exit 0
+          # `git commit || exit 0` swallowed real failures along with the
+          # nothing-to-commit case, and skipped the push with them. Ask
+          # directly whether anything is staged.
+          if git diff --cached --quiet; then
+            echo "manifest already at ${{ needs.version.outputs.version }} — nothing to commit"
+            exit 0
+          fi
+          git commit -m "osprey ${{ needs.version.outputs.version }}"
           git push
 
   # --------------------------------------------------------------------------
@@ -360,9 +399,8 @@ jobs:
     # rebuilt at the new tag version.
     if: ${{ needs.scope.outputs.vsix == 'true' }}
     runs-on: ${{ matrix.os }}
-    # Match the build job: a win32 VSIX hiccup must not block the mac/linux
-    # VSIXes from reaching the Marketplace.
-    continue-on-error: ${{ matrix.target == 'win32-x64' }}
+    # Matches the build job: every target is blocking, and a failing leg still
+    # lets its siblings finish so one run shows every platform's result.
     strategy:
       fail-fast: false
       matrix:
@@ -494,7 +532,6 @@ jobs:
   publish-openvsx:
     name: Publish VSIX to Open VSX
     needs: [version, vsix, preflight]
-    if: ${{ needs.preflight.outputs.has_ovsx == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: release
@@ -554,9 +591,88 @@ jobs:
   deploy-webcompiler:
     name: Deploy web compiler
     needs: [github-release]
-    # Non-blocking: the browser compiler on Fly.io is an optional add-on, not a
-    # release artifact. The deploy step itself is `continue-on-error` inside
-    # deploy-webcompiler.yml (continue-on-error is not valid on a `uses:` job),
-    # so a Fly outage or invalid/banned FLY_API_TOKEN can't fail the release.
+    # Blocking, like every other channel. This deploy used to be non-fatal, and
+    # the live playground consequently served a stale build for weeks behind a
+    # green release. Nothing depends on this job, so failing it stops nothing —
+    # it only makes the run red.
     uses: ./.github/workflows/deploy-webcompiler.yml
     secrets: inherit
+
+  # --------------------------------------------------------------------------
+  # THE BACKSTOP. Every job above can fail the run by failing. None of them can
+  # fail it by not running — GitHub scores a skipped job as green, so a wrong
+  # `if:`, an unset scope output or a cancelled dependency silently produces a
+  # release that published nothing and reported success. This job is the one
+  # place that states what a release is *required* to have done.
+  #
+  # It cancels nothing: `if: always()` waits for every job to reach a conclusion
+  # first, so a failing leg still lets its siblings finish and report.
+  #
+  # scripts/verify-release-gates.mjs asserts on every PR that this `needs:` list
+  # names every other job in this file — add a publish channel without wiring it
+  # in here and CI fails before a release can quietly skip it.
+  release-complete:
+    name: Release complete
+    needs:
+      - scope
+      - version
+      - build
+      - github-release
+      - preflight
+      - brew
+      - scoop
+      - vsix
+      - publish-marketplace
+      - publish-openvsx
+      - deploy-site
+      - deploy-webcompiler
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert the release actually happened
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+          # The scope job is the single source of truth for which surfaces this
+          # tag must publish. The assertion is driven by the same four outputs
+          # the jobs' own `if:` conditions use, so "ran" and "should have run"
+          # cannot drift apart silently.
+          WANT_FULL: ${{ needs.scope.outputs.full }}
+          WANT_BUILD: ${{ needs.scope.outputs.build_matrix }}
+          WANT_VSIX: ${{ needs.scope.outputs.vsix }}
+          WANT_SITE: ${{ needs.scope.outputs.website }}
+          # A SemVer prerelease tag (v1.2.3-rc.1) deliberately leaves the live
+          # site alone. That is the only reason deploy-site may skip.
+          IS_PRERELEASE: ${{ contains(github.ref_name, '-') }}
+        run: |
+          set -euo pipefail
+          echo "## Release job results" >> "$GITHUB_STEP_SUMMARY"
+          jq -r 'to_entries[] | "- \(.key): \(.value.result)"' <<< "$RESULTS" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+          broken=$(jq -r 'to_entries[]
+            | select(.value.result == "failure" or .value.result == "cancelled")
+            | "\(.key)(\(.value.result))"' <<< "$RESULTS" | tr '\n' ' ')
+
+          # These have no `if:` at all, so a skip means the run itself is broken.
+          required="scope version preflight"
+          [ "$WANT_BUILD" != "true" ] || required="$required build"
+          [ "$WANT_VSIX" != "true" ] || required="$required vsix publish-marketplace publish-openvsx"
+          [ "$WANT_FULL" != "true" ] || required="$required github-release brew scoop deploy-webcompiler"
+          if [ "$WANT_SITE" = "true" ] && [ "$IS_PRERELEASE" != "true" ]; then
+            required="$required deploy-site"
+          fi
+
+          # Anything merely skipped here is a channel that silently did not ship.
+          absent=""
+          for job in $required; do
+            result=$(jq -r --arg j "$job" '.[$j].result' <<< "$RESULTS")
+            [ "$result" = "success" ] || absent="$absent $job($result)"
+          done
+
+          if [ -n "$broken" ] || [ -n "$absent" ]; then
+            [ -z "$broken" ] || echo "::error title=Release job failed::${broken}"
+            [ -z "$absent" ] || echo "::error title=Release channel did not publish::This tag requires these to succeed and they did not:${absent}"
+            exit 1
+          fi
+          echo "Every channel this tag requires published: ${required}"

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,8 @@ lint: _deslop _lint
 _lint: $(EXT_NODE_DEPS)
 	@echo "==> Linting..."
 	node scripts/verify-node-deps-guard.mjs
+	node scripts/verify-release-gates.mjs
+	python3 scripts/test-release-gate.py
 	cargo fmt --all --check
 	cargo clippy --workspace --all-targets -- -D warnings
 	cd $(EXT_DIR) && npm run lint

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,17 +24,46 @@ That's it. The pipeline does the rest:
 
 1. **Resolve version** — `1.2.3` is derived from the tag and validated against
    `shipwright.json`.
-2. **Build** the compiler for `darwin-arm64`, `darwin-x64`, `linux-x64`, and
-   `win32-x64`, verify `osprey --version` prints `osprey 1.2.3`, and package each
-   as `osprey-1.2.3-<platform>.tar.gz` (binary + runtime libs) + `.sha256`.
+2. **Build** the compiler for `darwin-arm64`, `linux-x64` and `win32-x64`
+   (there is no Intel-mac leg — GitHub no longer allocates the free `macos-13`
+   runner), verify `osprey --version` prints `osprey 1.2.3`, and package each as
+   `osprey-1.2.3-<platform>.tar.gz` (binary + every runtime archive) + `.sha256`.
 3. **GitHub Release** on `Nimblesite/osprey` with all tarballs.
 4. **Homebrew** — writes `Formula/osprey.rb` to
    [`Nimblesite/homebrew-tap`](https://github.com/Nimblesite/homebrew-tap).
 5. **Scoop** — writes `bucket/osprey.json` to
    [`Nimblesite/scoop-bucket`](https://github.com/Nimblesite/scoop-bucket).
-6. **VS Code Marketplace** — publishes the per-platform VSIX as
+6. **VS Code Marketplace and Open VSX** — publish the per-platform VSIX as
    `nimblesite.osprey` (binary bundled and version-checked at activation).
 7. **Website + web compiler** deploy — only after every step above succeeds.
+
+## Any failure makes the run red
+
+A release is either published or it is not, so every channel blocks and nothing
+downgrades a failure to a warning.
+
+- **No job is optional.** The win32 build and VSIX legs were once
+  `continue-on-error`, and the web compiler deploy was non-fatal. A Windows
+  binary that never built, or a playground left on a stale image, reported green
+  and was found by users rather than by the pipeline.
+- **A missing credential fails before anything is built.** The publish tokens
+  used to be probed, and a missing one skipped its channel with a warning — a
+  release that never reached Homebrew still passed. `preflight` now requires
+  every one and names the ones that are absent.
+- **A skipped job is a failure too.** GitHub scores a skipped job as green, so a
+  wrong `if:` publishes nothing and still succeeds. The `release-complete` job
+  runs `if: always()` after every other job and fails unless each channel a full
+  stable release requires actually succeeded.
+- **Failing does not cancel.** `fail-fast: false` stays on both matrices, so a
+  broken leg still lets its siblings finish and one run shows every platform's
+  result. The run just ends red.
+
+[`scripts/verify-release-gates.mjs`](../scripts/verify-release-gates.mjs) holds
+this shape in place: it runs in `make lint` and in the required "Build, Format &
+Analyse" job, and fails the PR that reintroduces a swallowed failure or adds a
+release job without wiring it into `release-complete`. A `|| true` that is
+genuinely correct goes in that script's reviewed list with its reason; an entry
+that stops matching anything fails too, so the list cannot go stale.
 
 ## Versioning — never hard-code it ([SWR-VERSION-BUILD-STAMPING])
 
@@ -65,14 +94,19 @@ Configure these on `Nimblesite/osprey`:
 
 | Secret | Used by | Purpose |
 |--------|---------|---------|
-| `VSCE_PAT` | `vsix` job | VS Code Marketplace PAT for publisher `nimblesite`. |
-| `TAP_TOKEN` | `brew` job | PAT with push to `Nimblesite/homebrew-tap`. |
-| `SCOOP_BUCKET_TOKEN` | `scoop` job | PAT with push to `Nimblesite/scoop-bucket`. |
-| `FLY_API_TOKEN` | web compiler | Fly.io deploy (existing). |
+| `BREW_SCOOP_PAT` | `brew`, `scoop` | PAT with push to `Nimblesite/homebrew-tap` and `Nimblesite/scoop-bucket`. |
+| `OPEN_VSX_PAT` | `publish-openvsx` | Open VSX token for namespace `nimblesite`. |
+| `AZURE_CLIENT_ID` | `publish-marketplace` | Entra app id for the Marketplace OIDC publish. Not sensitive; a secret only for convenience. |
+| `AZURE_TENANT_ID` | `publish-marketplace` | Entra tenant id, likewise. |
+| `FLY_API_TOKEN` | `deploy-webcompiler` | Fly.io deploy. |
 
-The GitHub Release uses the built-in `GITHUB_TOKEN` (`contents: write`).
-Set repo **variable** `SKIP_VSCE_PUBLISH=true` to dry-run the VSIX build without
-publishing to the Marketplace.
+The GitHub Release uses the built-in `GITHUB_TOKEN` (`contents: write`), and the
+Marketplace publish mints a short-lived token from the Entra OIDC session rather
+than storing a PAT.
+
+`preflight` checks all four publish credentials before the build starts and
+fails the release naming any that are missing, so a token expiring is a red run
+at minute one rather than a channel that quietly did not publish.
 
 ## Installing released builds
 

--- a/scripts/test-release-gate.py
+++ b/scripts/test-release-gate.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Decision table for release.yml's `release-complete` backstop.
+
+That job is the only thing standing between a release that published nothing and
+a green tick, and it runs exactly once per tag — on a tag, where a mistake in it
+is discovered by users. So its logic is exercised here against fabricated job
+results instead of being trusted.
+
+The shell under test is read out of the workflow rather than copied, so there is
+one implementation: edit the gate and this runs the edited gate. If the step's
+shape changes so the body can no longer be found, that is a failure too — a test
+that silently stops testing is worse than no test.
+"""
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+WORKFLOW = pathlib.Path(".github/workflows/release.yml")
+STEP = "Assert the release actually happened"
+RUN_BLOCK = re.compile(r"^ {8}run: \|\n(?P<body>(?: {10}.*\n|\n)*)", re.MULTILINE)
+
+# Jobs whose outcome the gate is asked about, in the order the table lists them.
+JOBS = (
+    "build",
+    "github-release",
+    "brew",
+    "scoop",
+    "vsix",
+    "publish-marketplace",
+    "publish-openvsx",
+    "deploy-site",
+    "deploy-webcompiler",
+)
+ALWAYS_RUN = ("scope", "version", "preflight")
+
+OK, SKIP, FAIL, CANCEL = "success", "skipped", "failure", "cancelled"
+
+# (label, expect_pass, per-job results, full, build_matrix, vsix, website, prerelease)
+TABLE = (
+    ("full release, every channel published", True,
+     (OK, OK, OK, OK, OK, OK, OK, OK, OK), "true", "true", "true", "true", "false"),
+    ("full release, Homebrew silently skipped", False,
+     (OK, OK, SKIP, OK, OK, OK, OK, OK, OK), "true", "true", "true", "true", "false"),
+    ("full release, a build leg failed", False,
+     (FAIL, SKIP, SKIP, SKIP, SKIP, SKIP, SKIP, OK, SKIP), "true", "true", "true", "true", "false"),
+    ("full release, web compiler deploy failed", False,
+     (OK, OK, OK, OK, OK, OK, OK, OK, FAIL), "true", "true", "true", "true", "false"),
+    ("full release, a job was cancelled", False,
+     (OK, OK, OK, CANCEL, OK, OK, OK, OK, OK), "true", "true", "true", "true", "false"),
+    ("website-only tag, site deployed", True,
+     (SKIP, SKIP, SKIP, SKIP, SKIP, SKIP, SKIP, OK, SKIP), "false", "false", "false", "true", "false"),
+    ("website-only tag, site silently skipped", False,
+     (SKIP,) * 9, "false", "false", "false", "true", "false"),
+    # A cancelled job this tag does not require is caught only by the
+    # failure/cancelled sweep, so this is the case that pins that sweep.
+    ("website-only tag, an unrequired job was cancelled", False,
+     (CANCEL, SKIP, SKIP, SKIP, SKIP, SKIP, SKIP, OK, SKIP), "false", "false", "false", "true", "false"),
+    ("prerelease leaves the live site alone", True,
+     (OK, OK, OK, OK, OK, OK, OK, SKIP, OK), "true", "true", "true", "true", "true"),
+    ("prerelease, Open VSX skipped", False,
+     (OK, OK, OK, OK, OK, OK, SKIP, SKIP, OK), "true", "true", "true", "true", "true"),
+    ("vsix-only tag, extension published", True,
+     (OK, SKIP, SKIP, SKIP, OK, OK, OK, SKIP, SKIP), "false", "true", "true", "false", "false"),
+    ("vsix-only tag, Marketplace skipped", False,
+     (OK, SKIP, SKIP, SKIP, OK, SKIP, OK, SKIP, SKIP), "false", "true", "true", "false", "false"),
+    ("a job that should always run did not", False,
+     (OK, OK, OK, OK, OK, OK, OK, OK, OK), "true", "true", "true", "true", "false"),
+)
+
+
+def gate_script(text):
+    """The `run:` body of the backstop step, de-indented into a runnable script."""
+    at = text.find(STEP)
+    if at == -1:
+        sys.exit(f"{WORKFLOW}: no step named {STEP!r} — the backstop is gone or renamed")
+    block = RUN_BLOCK.search(text, at)
+    if block is None:
+        sys.exit(f"{WORKFLOW}: found {STEP!r} but no `run: |` body under it")
+    body = "".join(line[10:] if line.startswith(" " * 10) else line
+                   for line in block.group("body").splitlines(keepends=True))
+    if "release-complete" not in text or "required=" not in body:
+        sys.exit(f"{WORKFLOW}: the extracted body is not the backstop — the parser is broken")
+    return body
+
+
+def run(script, results, scope, summary):
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        "GITHUB_STEP_SUMMARY": summary,
+        "RESULTS": json.dumps(results),
+        "WANT_FULL": scope[0], "WANT_BUILD": scope[1], "WANT_VSIX": scope[2],
+        "WANT_SITE": scope[3], "IS_PRERELEASE": scope[4],
+    }
+    done = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+    return done.returncode == 0, done.stdout + done.stderr
+
+
+def main():
+    script = gate_script(WORKFLOW.read_text())
+    failures = []
+    with tempfile.NamedTemporaryFile(suffix=".md") as summary:
+        for label, expect_pass, outcomes, *scope in TABLE:
+            results = {job: {"result": OK} for job in ALWAYS_RUN}
+            # The last row drops an unconditional job to prove the gate notices.
+            if label.startswith("a job that should always run"):
+                results["preflight"] = {"result": SKIP}
+            results.update({job: {"result": r} for job, r in zip(JOBS, outcomes)})
+            passed, output = run(script, results, scope, summary.name)
+            if passed != expect_pass:
+                failures.append(f"{label}: expected {'pass' if expect_pass else 'fail'}, got "
+                                f"{'pass' if passed else 'fail'}\n{output}")
+            else:
+                print(f"  ok   {label}")
+
+    if failures:
+        print("\nrelease gate decision table: FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"release gate decision table: OK ({len(TABLE)} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-release-gates.mjs
+++ b/scripts/verify-release-gates.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// The release pipeline is the one workflow nobody watches until it matters, and
+// it had four separate ways to publish nothing and report success: win32 build
+// and VSIX legs marked `continue-on-error`, runtime archives copied with `||
+// true`, a token probe that turned a missing credential into a skipped publish,
+// and `git commit || exit 0` swallowing a failed tap push. Each was defensible
+// on its own; together they meant "green" did not mean "released".
+//
+// Removing them is not enough, because the failure mode that survives is a job
+// that never runs: GitHub scores a skipped job as green, so a wrong `if:` or an
+// unset scope output silently produces a release that shipped nothing. The
+// `release-complete` job in release.yml is the backstop for that, and this
+// check is the backstop for the backstop — it fails the PR that would let any
+// of it back in.
+//
+// Like verify-node-deps-guard.mjs this is a script inside an already-required
+// job, not a new required check, so the pinned context list in
+// verify-branch-protection.mjs and the ruleset stay in agreement.
+import { readFileSync, readdirSync } from 'node:fs'
+
+const WORKFLOW_DIR = '.github/workflows'
+const RELEASE_WORKFLOW = 'release.yml'
+const GATE_JOB = 'release-complete'
+const GATE_CONDITION = 'if: always()'
+
+// A run step may not tolerate a failure. One does, for a reason that holds: it
+// is followed by an explicit check that fails loudly on the bad case, so the
+// tolerance buys a clear diagnostic rather than hiding anything.
+//
+// The set is compared exactly. An entry matching nothing fails too — a stale
+// exemption is a hole with nobody looking at it.
+const REVIEWED_TOLERANCES = [
+  {
+    file: 'release-change-detection.yml',
+    fragment: 'prev="$(git describe',
+    reason: 'first release has no previous tag: the empty result selects the publish-everything branch',
+  },
+]
+
+const SWALLOWS = [
+  { pattern: /continue-on-error/, name: 'continue-on-error' },
+  { pattern: /\|\|\s*true\b/, name: '|| true' },
+  { pattern: /\|\|\s*exit 0\b/, name: '|| exit 0' },
+]
+
+const isComment = (line) => line.trimStart().startsWith('#')
+
+const workflowFiles = readdirSync(WORKFLOW_DIR).filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+
+const readWorkflow = (file) => readFileSync(`${WORKFLOW_DIR}/${file}`, 'utf8').split('\n')
+
+// Every tolerated line across the tree, as {file, line, text, swallow}.
+const toleranceSites = workflowFiles.flatMap((file) =>
+  readWorkflow(file)
+    .map((text, index) => ({ file, line: index + 1, text }))
+    .filter(({ text }) => !isComment(text))
+    .flatMap((site) => SWALLOWS.filter(({ pattern }) => pattern.test(site.text)).map(({ name }) => ({ ...site, swallow: name }))),
+)
+
+const isReviewed = (site) =>
+  REVIEWED_TOLERANCES.some((entry) => entry.file === site.file && site.text.includes(entry.fragment))
+
+const unreviewed = toleranceSites
+  .filter((site) => !isReviewed(site))
+  .map((site) => `${site.file}:${site.line}: \`${site.swallow}\` — a failed step here reports success`)
+
+const stale = REVIEWED_TOLERANCES.filter(
+  (entry) => !toleranceSites.some((site) => site.file === entry.file && site.text.includes(entry.fragment)),
+).map((entry) => `reviewed tolerance no longer present: ${entry.file} \`${entry.fragment}\` — delete the entry`)
+
+// ---- The release backstop must name every job it is backstopping ------------
+
+const releaseLines = readWorkflow(RELEASE_WORKFLOW)
+
+const jobsStart = releaseLines.findIndex((line) => line === 'jobs:')
+
+const jobNames = releaseLines
+  .slice(jobsStart + 1)
+  .filter((line) => !isComment(line))
+  .map((line) => line.match(/^ {2}([A-Za-z][A-Za-z0-9_-]*):\s*$/))
+  .filter((match) => match !== null)
+  .map((match) => match[1])
+
+// The gate job's own block: from its header to the next job at the same indent.
+const gateStart = releaseLines.findIndex((line) => line === `  ${GATE_JOB}:`)
+const gateRest = releaseLines.slice(gateStart + 1)
+const gateEnd = gateRest.findIndex((line) => /^ {2}[A-Za-z]/.test(line))
+const gateBlock = gateEnd === -1 ? gateRest : gateRest.slice(0, gateEnd)
+
+const takeWhile = (items, keep) => {
+  const stop = items.findIndex((item) => !keep(item))
+  return stop === -1 ? items : items.slice(0, stop)
+}
+
+// `needs:` is either an inline flow sequence or a block list of `- name`.
+const NEEDS_ITEM = /^ {6}- ([A-Za-z][A-Za-z0-9_-]*)\s*$/
+const readNeeds = (block) => {
+  const at = block.findIndex((line) => /^ {4}needs:/.test(line))
+  if (at === -1) return []
+  const inline = block[at].match(/needs:\s*\[(.*)\]/)
+  if (inline) return inline[1].split(',').map((name) => name.trim()).filter(Boolean)
+  return takeWhile(block.slice(at + 1), (line) => NEEDS_ITEM.test(line)).map((line) => line.match(NEEDS_ITEM)[1])
+}
+
+const backstopped = jobNames.filter((name) => name !== GATE_JOB)
+const declared = readNeeds(gateBlock)
+const unguarded = backstopped
+  .filter((name) => !declared.includes(name))
+  .map((name) => `${RELEASE_WORKFLOW}: job \`${name}\` is not in \`${GATE_JOB}\`'s needs — it can skip and the release still reports green`)
+const phantom = declared
+  .filter((name) => !backstopped.includes(name))
+  .map((name) => `${RELEASE_WORKFLOW}: \`${GATE_JOB}\` needs \`${name}\`, which is not a job in this workflow`)
+
+const conditionMissing = gateBlock.some((line) => line.trim() === GATE_CONDITION)
+  ? []
+  : [`${RELEASE_WORKFLOW}: \`${GATE_JOB}\` must be \`${GATE_CONDITION}\` or it is skipped by the failure it exists to catch`]
+
+// ---- A gate that cannot run must not report success -------------------------
+
+const brokenParser = []
+if (jobsStart === -1) brokenParser.push(`no \`jobs:\` key in ${RELEASE_WORKFLOW} — the parser is broken, not the workflow`)
+if (gateStart === -1) brokenParser.push(`no \`${GATE_JOB}\` job in ${RELEASE_WORKFLOW} — the release backstop is gone`)
+if (jobNames.length < 8) brokenParser.push(`parsed only ${jobNames.length} jobs from ${RELEASE_WORKFLOW} — the parser is broken`)
+if (workflowFiles.length < 4) brokenParser.push(`found only ${workflowFiles.length} workflow files — this check is scanning nothing`)
+
+const failures = [...brokenParser, ...unreviewed, ...stale, ...unguarded, ...phantom, ...conditionMissing]
+
+if (failures.length > 0) {
+  console.error('release gate guard: FAIL')
+  for (const failure of failures) console.error(`  - ${failure}`)
+  console.error('\nA release that cannot publish must go red. Fix the workflow, or add a')
+  console.error('reviewed entry to REVIEWED_TOLERANCES with the reason it is safe.')
+  process.exit(1)
+}
+
+console.error(
+  `release gate guard: OK (${workflowFiles.length} workflows scanned, ${backstopped.length} release jobs all backstopped by ${GATE_JOB})`,
+)


### PR DESCRIPTION
<!-- agent-pmo:74cf183 -->
## TL;DR

The release pipeline had five ways to publish nothing and still report success. v0.17.0 went out through all of them intact. This makes every one of them a red run, and adds a backstop for the failure mode none of them covered: a job that never runs at all.

## Details

A release is either published or it is not. These each downgraded "did not publish" to something quieter:

| Where | What it swallowed |
| --- | --- |
| `build` / `vsix` matrices | `continue-on-error` on win32 — a Windows binary that never built was a warning inside a green run |
| `Package` step | `cp compiler/lib/lib*.a ... \|\| true` — a build producing no runtime archives would package, publish and reach Homebrew as a compiler that can link nothing |
| `preflight` | a missing publish token skipped its channel with a warning, so a release reaching neither Homebrew, Scoop nor Open VSX passed while `brew install` served the previous version |
| `brew` / `scoop` | `git commit ... \|\| exit 0` swallowed every commit failure along with the nothing-to-commit case, and skipped the push with it |
| `deploy-webcompiler` | non-fatal by design — which is how the live playground served a stale build for weeks behind green releases |

All five now fail the run. **Nothing cancels:** `fail-fast: false` stays on both matrices, so a broken leg still lets its siblings finish and one run shows every platform's result. It just ends red.

**The backstop.** Removing the swallows does not address the failure mode that survives: GitHub scores a *skipped* job as green, so a wrong `if:`, an unset scope output or a cancelled dependency publishes nothing and still succeeds. The new `release-complete` job runs `if: always()` after every other job and fails unless each channel this tag requires actually succeeded. It is driven by the same four `scope` outputs the jobs' own `if:` conditions use, so "ran" and "should have run" cannot drift apart.

Two same-class defects outside the release path are fixed too: the `|| true` hiding a failed `cargo install cargo-llvm-cov` behind a confusing error several steps later, and the one on the Android `sdkmanager` lookup, now a directory test with a real diagnostic.

`docs/RELEASING.md` gains a section stating the policy, and its secrets table is corrected — it named `VSCE_PAT`, `TAP_TOKEN` and `SCOOP_BUCKET_TOKEN`, none of which exist. The real credentials are `BREW_SCOOP_PAT`, `OPEN_VSX_PAT`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` and `FLY_API_TOKEN`. It also still advertised a `darwin-x64` build leg that was dropped, and a `SKIP_VSCE_PUBLISH` variable nothing reads.

## How Do The Automated Tests Prove It Works?

**The backstop's logic is executed, not eyeballed.** `scripts/test-release-gate.py` extracts the `release-complete` shell body *out of release.yml* — the real one, so there is no second copy to drift — and runs it under bash against 13 fabricated sets of job outcomes:

- a full release with everything published → passes
- Homebrew silently skipped, a build leg failed, a job cancelled, the web compiler deploy failed → each fails
- a website-only tag whose site deployed → passes; the same tag with the site silently skipped → fails
- a vsix-only tag whose extension published → passes; the same with the Marketplace publish skipped → fails
- a prerelease correctly leaving the live site alone → passes; the same prerelease with Open VSX skipped → fails
- a job with no `if:` at all that did not run → fails

Six mutations of the gate were each confirmed to turn the suite red: dropping the unconditional jobs from `required`, no longer distinguishing `skipped` from `success`, no longer counting `cancelled` as broken, ignoring the `website` output, always exiting 0, and renaming the step out from under the test. The `cancelled` mutation **initially slipped through**, which exposed a real gap — a cancelled job the tag does not require is caught only by the failure sweep, and no case covered that. Case 7 now pins it, and the mutation is caught.

**The swallows cannot come back.** `scripts/verify-release-gates.mjs` scans every workflow and fails on `continue-on-error`, `|| true` or `|| exit 0` in a run step, on any release job missing from `release-complete`'s `needs:`, on a renamed or deleted backstop, on a backstop without `if: always()`, and on a reviewed tolerance that no longer matches anything. Eight regressions were each confirmed caught — including adding a plausible new `publish-snap` job and forgetting to wire it in — with the workflow tree checksummed back to identical after every probe. The single surviving `|| true`, the first-release tag lookup in `release-change-detection.yml`, is in the script's reviewed list with the reason it is safe; deleting the tolerance without deleting the entry fails the build.

Both run in `make lint` and as a step in the already-required **Build, Format & Analyse** job, so the pinned context list in `verify-branch-protection.mjs` and the ruleset stay in agreement — no new required check, no ruleset edit.

`actionlint` is clean across all six workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
